### PR TITLE
Java SSL client certificate header

### DIFF
--- a/deployment-examples/kubernetes/microk8s/ejbca-ce-with-ingress-and-mariadb.yaml
+++ b/deployment-examples/kubernetes/microk8s/ejbca-ce-with-ingress-and-mariadb.yaml
@@ -19,6 +19,9 @@ metadata:
     #nginx.ingress.kubernetes.io/auth-tls-secret: "default/ca-secret"
     #nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
     #nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    # Hook
+    # nginx.ingress.kubernetes.io/configuration-snippet: |
+    #   proxy_set_header SSL_CLIENT_CERT $ssl_client_cert;
     # AJP is available in nginx-ingress-controller:0.18.0 and later
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/affinity: "cookie"


### PR DESCRIPTION
Without this header, he not worked with kubernetes ingress.